### PR TITLE
Fix PCH errors. Create Get<>(ActorContext) interface.

### DIFF
--- a/Source/ComponentPicker/Public/ComponentPickerStruct.h
+++ b/Source/ComponentPicker/Public/ComponentPickerStruct.h
@@ -4,6 +4,8 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "GameFramework/Actor.h"
 #include "UObject/Object.h"
 #include "ComponentPickerStruct.generated.h"
 
@@ -33,12 +35,37 @@ public:
 	{
 		if (!Instance.IsExplicitlyNull())
 			return Instance.Get();
+
+		if (ComponentContext == nullptr)
+			return nullptr;
+		
+		return Get(ComponentContext->GetOwner());
+	}
+
+	/** Get the currently selected component pre-casted. */
+	template<typename TComponentClass>
+	TComponentClass* Get(const AActor* ActorContext) const
+	{
+		return Cast<TComponentClass>(Get(ActorContext));
+	}
+
+	/** Get the currently selected component. */
+	UActorComponent* Get(const AActor* ActorContext) const
+	{
+		if (!Instance.IsExplicitlyNull())
+			return Instance.Get();
+
+		if (ActorContext == nullptr)
+			return nullptr;
+
+		if (!IsSet())
+			return nullptr;
 		
 		FString ComponentStr = Component->GetFName().ToString();
 		ComponentStr.RemoveFromEnd("_GEN_VARIABLE");
 		const FName ComponentName = FName(ComponentStr);
 		
-		const TSet<UActorComponent*>& OwnedComponents = ComponentContext->GetOwner()->GetComponents();
+		const TSet<UActorComponent*>& OwnedComponents = ActorContext->GetComponents();
 		for (auto* ComponentInstance : OwnedComponents)
 		{
 			if (ComponentInstance->GetName() == ComponentName)

--- a/Source/ComponentPickerEditor/ComponentPickerEditor.Build.cs
+++ b/Source/ComponentPickerEditor/ComponentPickerEditor.Build.cs
@@ -30,7 +30,8 @@ public class ComponentPickerEditor : ModuleRules
                 "CoreUObject",
                 "Engine",
                 "Slate",
-                "SlateCore"
+                "SlateCore",
+                "PropertyEditor"
             }
         );
     }

--- a/Source/ComponentPickerEditor/Private/ComponentPickerEditor.cpp
+++ b/Source/ComponentPickerEditor/Private/ComponentPickerEditor.cpp
@@ -2,6 +2,7 @@
 // Released under the MIT license https://opensource.org/license/MIT/
 
 #include "ComponentPickerEditor.h"
+#include "PropertyEditorModule.h"
 
 #include "ComponentPickerTypeCustomization.h"
 

--- a/Source/ComponentPickerEditor/Public/ComponentPickerTypeCustomization.h
+++ b/Source/ComponentPickerEditor/Public/ComponentPickerTypeCustomization.h
@@ -5,6 +5,7 @@
 #include "CoreMinimal.h"
 #include "BlueprintEditor.h"
 #include "SSubobjectEditor.h"
+#include "IPropertyTypeCustomization.h"
 
 /**
  * Editor property customization for @FComponentPicker.

--- a/Source/ComponentPickerEditor/Public/PublicPropertyEditorButton.h
+++ b/Source/ComponentPickerEditor/Public/PublicPropertyEditorButton.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/Input/SButton.h"
 
 /**
  * Standardized property editor button.


### PR DESCRIPTION
fixes several non-unity/no-pch errors. 
And add Get() function that takes an actor instead of a component.